### PR TITLE
Roomba example correction

### DIFF
--- a/decision_making_examples/src/fsm/Roomba.cpp
+++ b/decision_making_examples/src/fsm/Roomba.cpp
@@ -106,6 +106,7 @@ int main(int argc, char** argv){
 	/**
 	 * Blocking call
 	 */
+  mainEventQueue->async_spin();
 	FsmRoomba(NULL, mainEventQueue);
 
 	spinner.stop();


### PR DESCRIPTION
The event queue async_spin call was missing.

Solution of issue #10.
