### PR TITLE
Compilation on Ubuntu14.04+Indigo

### DIFF
--- a/decision_making/include/decision_making/EventSystem.h
+++ b/decision_making/include/decision_making/EventSystem.h
@@ -70,12 +70,12 @@ public:
 	template<class A>
 	A& parameters()const{
 		if(isParametersDefined()==false) throw ExceptionParametersUndefined();
-		return *(boost::shared_static_cast<A>(_parameters).get());
+		return *(boost::static_pointer_cast<A>(_parameters).get());
 	}
 	template<class A>
 	A& parameters(){
 		if(isParametersDefined()==false) createParameters<A>();
-		return *(boost::shared_static_cast<A>(_parameters).get());
+		return *(boost::static_pointer_cast<A>(_parameters).get());
 	}
 };
 typedef CallContext FSMCallContext;

--- a/decision_making_parser/CMakeLists.txt
+++ b/decision_making_parser/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 )       
       
 ## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
+find_package(Boost REQUIRED COMPONENTS system)
       
  
 ## Uncomment this if the package has a setup.py. This macro ensures
@@ -146,9 +146,10 @@ FILE(WRITE "${XMLPARSER}" "${SRC_XML_PARSER_TEXT}" )
 # add_dependencies(decision_making_parser_node decision_making_parser_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
-# target_link_libraries(decision_making_parser_node
+target_link_libraries(tao_parser_test
+    ${Boost_SYSTEM_LIBRARY}   
 #   ${catkin_LIBRARIES}
-# )
+)
 
 #############
 ## Install ##


### PR DESCRIPTION
Changed boost::shared_static_cast to boost::static_pointer_cast. Added the missing library in CMakeFiles.txt. Changes allow compilation on Ubuntu 14.04+ROS indigo. The library continues to work on Ubuntu 12.04+ROS Hydro with these changes.