### PR TITLE
Changes in the module import from python_qt_binding due to Qt5 changes (Kinetic upgrade)

### DIFF
--- a/rqt_decision_graph/src/rqt_decision_graph/decision_making_graph.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/decision_making_graph.py
@@ -28,7 +28,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-from python_qt_binding.QtGui import QWidget
+from python_qt_binding.QtWidgets import QWidget
 import rospkg
 import rospy
 from diagnostic_msgs.msg import DiagnosticArray

--- a/rqt_decision_graph/src/rqt_decision_graph/dmg_html_node_item.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/dmg_html_node_item.py
@@ -29,7 +29,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from python_qt_binding.QtCore import Qt
-from python_qt_binding.QtGui import QBrush, QGraphicsTextItem, QPen, QPainterPath, QColor
+from python_qt_binding.QtGui import QBrush, QPen, QPainterPath, QColor
+from python_qt_binding.QtWidgets import QGraphicsTextItem
 from .graph_item import GraphItem
 from .shape_factory import ShapeFactory
 

--- a/rqt_decision_graph/src/rqt_decision_graph/dmg_node_item.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/dmg_node_item.py
@@ -29,7 +29,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from python_qt_binding.QtCore import Qt
-from python_qt_binding.QtGui import QBrush, QGraphicsSimpleTextItem, QPen, QColor
+from python_qt_binding.QtGui import QBrush, QPen, QColor
+from python_qt_binding.QtWidgets import QGraphicsSimpleTextItem
 from .hovered_node_item import HoveredNodeItem
 
 

--- a/rqt_decision_graph/src/rqt_decision_graph/dot_processor.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/dot_processor.py
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from __future__ import division
-from python_qt_binding.QtGui import QGraphicsTextItem
+from python_qt_binding.QtWidgets import QGraphicsTextItem
 from pydot import *
 
 POINTS_PER_INCH = 72

--- a/rqt_decision_graph/src/rqt_decision_graph/edge_item.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/edge_item.py
@@ -33,8 +33,8 @@ Note: This is modified version by Cogniteam
 """
 
 from python_qt_binding.QtCore import Qt, QPointF
-from python_qt_binding.QtGui import QBrush, QGraphicsSimpleTextItem, QPen, QColor, QPainterPath, QGraphicsPolygonItem, \
-                                    QPolygonF, QPainterPath, QGraphicsPathItem
+from python_qt_binding.QtGui import QBrush, QPen, QColor, QPainterPath, QPolygonF, QPainterPath
+from python_qt_binding.QtWidgets import QGraphicsSimpleTextItem, QGraphicsPolygonItem, QGraphicsPathItem
 
 from .graph_item import GraphItem
 

--- a/rqt_decision_graph/src/rqt_decision_graph/graph_item.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/graph_item.py
@@ -32,7 +32,8 @@ POSSIBILITY OF SUCH DAMAGE.
 Note: This is modified version by Cogniteam
 """
 
-from python_qt_binding.QtGui import QGraphicsItemGroup, QColor
+from python_qt_binding.QtGui import QColor
+from python_qt_binding.QtWidgets import QGraphicsItemGroup
 
 
 class GraphItem(QGraphicsItemGroup):

--- a/rqt_decision_graph/src/rqt_decision_graph/graph_widget.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/graph_widget.py
@@ -33,7 +33,8 @@ from os import path
 from threading import Lock
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import Qt
-from python_qt_binding.QtGui import QFileDialog, QGraphicsScene, QIcon, QImage, QPainter, QWidget, QColor, QComboBox
+from python_qt_binding.QtGui import QIcon, QImage, QPainter, QColor
+from python_qt_binding.QtWidgets import QFileDialog, QGraphicsScene, QWidget, QComboBox
 from collections import namedtuple
 from .interactive_graphics_view import InteractiveGraphicsView
 from .decision_graph import DecisionGraph

--- a/rqt_decision_graph/src/rqt_decision_graph/hovered_edge_item.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/hovered_edge_item.py
@@ -33,8 +33,8 @@ Note: This is modified version by Cogniteam
 """
 
 from python_qt_binding.QtCore import Qt, QPointF
-from python_qt_binding.QtGui import QBrush, QGraphicsSimpleTextItem, QPen, QColor, QPainterPath, QGraphicsPolygonItem, \
-                                    QPolygonF, QPainterPath, QGraphicsPathItem
+from python_qt_binding.QtGui import QBrush, QPen, QColor, QPainterPath, QPolygonF, QPainterPath
+from python_qt_binding.QtWidgets import QGraphicsPolygonItem, QGraphicsPathItem, QGraphicsSimpleTextItem
 from .edge_item import EdgeItem
 
 

--- a/rqt_decision_graph/src/rqt_decision_graph/hovered_node_item.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/hovered_node_item.py
@@ -33,7 +33,8 @@ Note: This is modified version by CogniTeam
 """
 
 from python_qt_binding.QtCore import Qt
-from python_qt_binding.QtGui import QBrush, QGraphicsSimpleTextItem, QPen, QPainterPath, QColor
+from python_qt_binding.QtGui import QBrush, QPen, QPainterPath, QColor
+from python_qt_binding.QtWidgets import QGraphicsSimpleTextItem
 from .node_item import NodeItem
 
 

--- a/rqt_decision_graph/src/rqt_decision_graph/interactive_graphics_view.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/interactive_graphics_view.py
@@ -35,7 +35,8 @@ Note: This is modified version by Cogniteam
 from __future__ import division
 
 from python_qt_binding.QtCore import QPointF, QRectF, Qt
-from python_qt_binding.QtGui import QGraphicsView, QTransform
+from python_qt_binding.QtGui import QTransform
+from python_qt_binding.QtWidgets import QGraphicsView
 
 
 class InteractiveGraphicsView(QGraphicsView):

--- a/rqt_decision_graph/src/rqt_decision_graph/node_item.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/node_item.py
@@ -33,7 +33,8 @@ Note: This is modified version by Cogniteam
 """
 
 from python_qt_binding.QtCore import Qt
-from python_qt_binding.QtGui import QBrush, QGraphicsSimpleTextItem, QPen
+from python_qt_binding.QtGui import QBrush, QPen
+from python_qt_binding.QtWidgets import QGraphicsSimpleTextItem
 
 from .graph_item import GraphItem
 from .shape_factory import ShapeFactory

--- a/rqt_decision_graph/src/rqt_decision_graph/shape_factory.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/shape_factory.py
@@ -31,8 +31,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from __future__ import division
 
 from python_qt_binding.QtCore import Qt, QPointF
-from python_qt_binding.QtGui import QBrush, QGraphicsEllipseItem, QGraphicsRectItem, QGraphicsSimpleTextItem, \
-                                    QPainterPath, QPen, QGraphicsPolygonItem, QPolygonF
+from python_qt_binding.QtGui import QBrush, QPainterPath, QPen, QPolygonF
+from python_qt_binding.QtWidgets import QGraphicsEllipseItem, QGraphicsRectItem, QGraphicsSimpleTextItem,\
+                                        QGraphicsPolygonItem
 
 
 class StaticClassError(Exception):


### PR DESCRIPTION
In 16.04/Kinetic, rqt uses Qt5 (see the [migration guide](http://wiki.ros.org/kinetic/Migration)). There, some modules have been moved, as for instance QWidget that is not in QtGui, but in QtWidgets, see e.g. [this ros answer](http://answers.ros.org/question/235126/import-issues-in-ros-kinetic-rqt/).

This PR updates all the imports.

The fsm_roomba example works as before, here the screenshot proof:
![fsm_roomba](https://db.tt/1PskLRhj)

Note that, merging this PR makes the `decision_making` pkg not usable in previous ROS versions. And if you do merge, please consider releasing to Kinetic, I prefer this package ten times over [smach](http://wiki.ros.org/smach). Thanks.