### PR TITLE
Member delta of QWheelEvent is obsolete, and the graph crashes with 16.04/Qt5

### DIFF
--- a/rqt_decision_graph/src/rqt_decision_graph/interactive_graphics_view.py
+++ b/rqt_decision_graph/src/rqt_decision_graph/interactive_graphics_view.py
@@ -69,7 +69,7 @@ class InteractiveGraphicsView(QGraphicsView):
 
     def wheelEvent(self, wheel_event):
         if wheel_event.modifiers() == Qt.NoModifier:
-            delta = wheel_event.delta()
+            delta = wheel_event.angleDelta().y()
             delta = max(min(delta, 480), -480)
             mouse_before_scale_in_scene = self.mapToScene(wheel_event.pos())
 


### PR DESCRIPTION
The new function is angleDelta() to get the wheel angle, see [1]. That
returns a QPoint, with x() and y().

In my PC, the wheel angle is returned in the y() component, but not really
sure if that applies generally to any PC.

[1] http://doc.qt.io/qt-5/qwheelevent-obsolete.html